### PR TITLE
Added a prefix option to support monorepo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ workflows:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
           context: orb-publishing-context
-          pub-type: production
+          # pub-type: production
           filters:
-            branches:
-              only: main
+            # branches:
+            #   only: main
             tags:
               only: /.*/
       # Triggers the next workflow in the Orb Development Kit.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ workflows:
           context: orb-publishing-context
           # pub-type: production
           filters:
-            # branches:
-            #   only: main
+            branches:
+              only: main
             tags:
               only: /.*/
       # Triggers the next workflow in the Orb Development Kit.

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - checkout
       # Run your orb's commands to validate them.
-      - git-tools/committag
+      - git-tools/committag:
+          tag_prefix: foobar
 
 workflows:
   test-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       # Run your orb's commands to validate them.
-      - git-tools/tag_prefix
+      - git-tools/committag
 
 workflows:
   test-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,4 +42,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       # Run your orb's commands to validate them.
-      - git-tools/prefix
+      - git-tools/tag_prefix
 
 workflows:
   test-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  <orb-name>: informed/git-tools@dev:<<pipeline.git.revision>>
+  git-tools: informed/git-tools@dev:<<pipeline.git.revision>>
   orb-tools: circleci/orb-tools@11.1
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,7 +37,7 @@ workflows:
           requires:
             - orb-tools/pack
             - command-tests
-          context: <publishing-context>
+          context: orb-publisher
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,4 +42,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,6 +17,9 @@ jobs:
       - checkout
       # Run your orb's commands to validate them.
       - git-tools/committag:
+          increment_patch: true
+          increment_tag: true
+          tag_pattern: '*[0-9]'
           tag_prefix: foobar
 
 workflows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,7 +16,10 @@ jobs:
       steps:
         - checkout
         # Run your orb's commands to validate them.
-        - <orb-name>/greet
+        - git-tools/prefix
+        -run:
+          name: verify prefix
+          command: command -v prefix foobar
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -8,18 +8,19 @@ filters: &filters
     only: /.*/
 
 jobs:
-    # Create a job to test the commands of your orbs.
-    # You may want to add additional validation steps to ensure the commands are working as expected.
-    command-tests:
-      docker:
-        - image: cimg/base:current
-      steps:
-        - checkout
-        # Run your orb's commands to validate them.
-        - git-tools/prefix
-        -run:
-          name: verify prefix
-          command: command -v prefix foobar
+  # Create a job to test the commands of your orbs.
+  # You may want to add additional validation steps to ensure the commands are working as expected.
+  command-tests:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      # Run your orb's commands to validate them.
+      - git-tools/prefix
+      -run:
+        name: verify prefix
+        command: command -v prefix foobar
+
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,9 +17,6 @@ jobs:
       - checkout
       # Run your orb's commands to validate them.
       - git-tools/prefix
-      -run:
-        name: verify prefix
-        command: command -v prefix foobar
 
 workflows:
   test-deploy:

--- a/src/commands/committag.yml
+++ b/src/commands/committag.yml
@@ -34,6 +34,11 @@ parameters:
       and prefix or suffix untouched. By default if set to true, a patch level
       increment will be made.
     type: boolean
+  tag_prefix:
+    default: ''
+    description: >-
+      Prefix to prepend to a SEMVER such as an app name in monorepo
+    type: string
   tag_pattern:
     default: '*'
     description: >-
@@ -51,8 +56,8 @@ steps:
           GITLATESTTAG=$(git tag --list "<<parameters.tag_pattern>>" | sort -V | tail -1)
           printf " Latest matching tag: $(git tag --list "<<parameters.tag_pattern>>" | sort -V | tail -1)"
           if [[ $GITLATESTTAG =~ ^(.*)(([0-9]+)\.([0-9]+)\.([0-9]+))(-.*)? ]]; then # If the tag has a valid SEMVER then proceed with upgrade
-            echo "    Prefix: ${BASH_REMATCH[1]}"
-            SEMPREFIX=${BASH_REMATCH[1]}
+            echo "    Incoming Prefix: ${BASH_REMATCH[1]}"
+            SEMPREFIX=${BASH_REMATCH[1]:-<<parameters.tag_prefix>>}
             echo "    Major: ${BASH_REMATCH[3]}"
             SEMVERMAJOR=${BASH_REMATCH[3]}
             echo "    Minor: ${BASH_REMATCH[4]}"


### PR DESCRIPTION
Added a new option that would allow you to supply a prefix to the SEMVER created by the orb. This is to support the monorepo where we will want to differentiate tags for each application inside the monorepo.

Not sure how to test / deploy it though. Could use some help